### PR TITLE
Parallel conversations

### DIFF
--- a/bartleby/bartleby.py
+++ b/bartleby/bartleby.py
@@ -50,13 +50,14 @@ async def main_matrix_loop(matrix_instance, llm_instance, docx_instance):
                             result = await matrix_instance.parse_command_message(
                                 llm_instance, 
                                 docx_instance, 
-                                user_message
+                                user_message,
+                                user
                             )
 
                         # Otherwise, Prompt the model with the user's message and post the
                         # model's response to chat
                         else: 
-                            model_output = llm_instance.prompt_model(user_message)
+                            model_output = llm_instance.prompt_model(user_message, user)
                             result = await matrix_instance.post_message(model_output, user)
 
 

--- a/bartleby/bartleby.py
+++ b/bartleby/bartleby.py
@@ -57,7 +57,7 @@ async def main_matrix_loop(matrix_instance, llm_instance, docx_instance):
                         # model's response to chat
                         else: 
                             model_output = llm_instance.prompt_model(user_message)
-                            result = await matrix_instance.post_message(model_output)
+                            result = await matrix_instance.post_message(model_output, user)
 
 
 def main_local_text_loop(llm_instance, docx_instance):

--- a/bartleby/docx_class.py
+++ b/bartleby/docx_class.py
@@ -18,7 +18,7 @@ class Docx:
         self.docx_template_file = conf.docx_template_file
         self.gdrive_folder_id = conf.gdrive_folder_id
 
-    async def async_generate(self, llm_instance):
+    async def async_generate(self, llm_instance, user):
         '''Recovers bot generated text from chat, formats as docx and
         pushes to google drive'''
 
@@ -29,7 +29,7 @@ class Docx:
         result = self.template.add_paragraph(self.title, style = 'Heading 1')
 
         # Get last message in chain
-        body = llm_instance.messages[-1]['content']
+        body = llm_instance.messages[user][-1]['content']
 
         # Split on newline so we can format paragraphs correctly
         paragraphs = body.split('\n')

--- a/bartleby/matrix_class.py
+++ b/bartleby/matrix_class.py
@@ -32,7 +32,7 @@ class Matrix:
             with open (self.next_batch_token_file,'r') as next_batch_token:
                 self.async_client.next_batch = next_batch_token.read()
 
-    async def post_message(self, message):
+    async def post_message(self, message, recipient='None'):
 
         # Get rid of any <strong> tags in message for unformatted body
         body = message.replace('<strong>', '').replace('</strong>', '')
@@ -43,11 +43,20 @@ class Matrix:
         # Format output as matrix message
         content = {
             'msgtype': 'm.text',
-            'format': 'org.matrix.custom.html',
-            'body': body,
-            'formatted_body': formatted_body
+            'format': 'org.matrix.custom.html'
         }
 
+        # Add mention for recipient if we have one, if not just
+        # add the message
+        if recipient == 'None':
+            content['body'] = body
+            content['formatted_body'] = formatted_body
+
+        elif recipient != 'None':
+            content['body'] = f'{recipient}: {body}'
+            content['formatted_body'] = f'<a href="https://matrix.to/#/@{recipient}:perdrizet.org">{recipient}</a>: {formatted_body}'
+            content['m.mentions'] = {'user_ids': [f'@{recipient}:perdrizet.org']}
+        
         # Post message to room
         result = await self.async_client.room_send(
             self.matrix_room_id, 

--- a/bartleby/matrix_class.py
+++ b/bartleby/matrix_class.py
@@ -104,7 +104,7 @@ class Matrix:
 
         return user_message
 
-    async def parse_command_message(self, llm_instance, document, command_message):
+    async def parse_command_message(self, llm_instance, document, command_message, user):
         '''Takes a user message that contains a command and runs the 
         command'''
 
@@ -130,14 +130,14 @@ class Matrix:
 
         # Update prompt with user input and reset message chain
         elif command[0] == '--update-prompt':
-            llm_instance.messages = [{'role': 'system', 'content': ' '.join(command[1:])}]
+            llm_instance.messages[user] = [{'role': 'system', 'content': ' '.join(command[1:])}]
             message = 'Prompt update complete'
             result = await self.post_message(message)
 
         # Generate docx document from document title and last chatbot response.
         # Save to documents and upload to gdrive
         elif command[0] == '--make-docx':
-            result = await document.generate(llm_instance)
+            result = await document.async_generate(llm_instance, user)
             message = 'Document complete'
             result = await self.post_message(message)
         


### PR DESCRIPTION
Parallel conversations in a Matrix room using the same LLM instance working. Uses a dictionary as the message buffer under a key for each user talking to the bot. Also added @mentions to bartleby's replies so that it is clear which user he is responding to.

Google docs functionality still works, not sure about Falcon, only tested Zepher. Probably other bugs still around and deserves a good clean-up and refactor, but it works.